### PR TITLE
Adding missing step to change dir into cloned repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Then, clone your forked version of the repository to your desktop in the termina
 
 `$ git clone https://github.com/YOUR-USERNAME/express-workshop`
 
+This creates an express-workshop directory with the repository content inside. Change into the express-workshop directory, since that's where we'll be working from now on.
+
+`$ cd express-workshop`
+
 ### [Go to Step 1 >>>>](https://github.com/node-girls/express-workshop/blob/master/step01.md)
 
 ## Useful Links


### PR DESCRIPTION
Adding a step here to change directory into the repo that the user has cloned, so they don't have problems later.

This isn't a problem until about Step 6 of the tutorial, but without changing into the express-workshop directory you won't have access to the assets required for Step 6 and the `app.use(express.static("public"));` call.