### PR TITLE
add MDN JS Reference to Useful Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ This creates an express-workshop directory with the repository content inside. C
 * [What is Node?](https://github.com/node-girls/what-is-node)
 * [Node cheatsheet](https://github.com/node-girls/cheatsheets/blob/master/node-cheatsheet.md)
 * [Command line cheatsheet](https://github.com/node-girls/cheatsheets/blob/master/command-line-cheatsheet.md)
+* [MDN Javascript Guides & Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript)

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ This creates an express-workshop directory with the repository content inside. C
 * [What is Node?](https://github.com/node-girls/what-is-node)
 * [Node cheatsheet](https://github.com/node-girls/cheatsheets/blob/master/node-cheatsheet.md)
 * [Command line cheatsheet](https://github.com/node-girls/cheatsheets/blob/master/command-line-cheatsheet.md)
-* [MDN Javascript Guides & Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
+* [MDN Javascript Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)


### PR DESCRIPTION
I thought I PR'd this on Monday but I can't see any evidence of it open or closed.  

Apologies if it is a dupe.